### PR TITLE
Use prepend_around_filter and bump version

### DIFF
--- a/lib/avocado/controller.rb
+++ b/lib/avocado/controller.rb
@@ -6,7 +6,7 @@ module Avocado
     extend ActiveSupport::Concern
 
     included do
-      around_action :store_request_and_response_in_avocado
+      prepend_around_action :store_request_and_response_in_avocado
     end
 
     def documentable?

--- a/lib/avocado/version.rb
+++ b/lib/avocado/version.rb
@@ -1,3 +1,3 @@
 module Avocado
-  VERSION = '3.0.7'
+  VERSION = '3.0.8'
 end


### PR DESCRIPTION
Prepending the around filter makes it the first around filter called (and last resolved), that way specs that use around filters to rescue exceptions can be documented.
